### PR TITLE
Better error handling when module is not found

### DIFF
--- a/lib/moonboots-static.js
+++ b/lib/moonboots-static.js
@@ -59,13 +59,21 @@ MoonbootsStatic.prototype.timingLog = function () {
     var timing = arguments[3];
     var message = arguments[2];
 
-    if (last(message.split(' ')) === 'finish') {
-        console.log(timingString(timing - this.lastTime) + message.replace('finish', ''));
-        this.lastTime = timing;
-    }
-    else if (message === 'built') {
-        console.log('-----------------------');
-        console.log(timingString(timing - this.initialTime) + 'Complete'.blue);
+    if( typeof message != 'object' ){
+
+        if (last(message.split(' ')) === 'finish') {
+            console.log(timingString(timing - this.lastTime) + message.replace('finish', ''));
+            this.lastTime = timing;
+        }
+        else if (message === 'built') {
+            console.log('-----------------------');
+            console.log(timingString(timing - this.initialTime) + 'Complete'.blue);
+        }
+
+    } else {
+
+        throw( message );
+        
     }
 };
 


### PR DESCRIPTION
I have added a type check for message so that when moonboots-static can not find a module it will indicate as such and throw an appropriate error instead of throwing an "TypeError: undefined is not a function"